### PR TITLE
Update pylint.yml

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'  # specify the Python version you are using
+        python-version: '3.10'
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Use Python 3.10 instead of 3.x for pylint.